### PR TITLE
[Refactor/firebase/trigger] 로드맵 생성 시 추후 트리거 추가 (구 : 트랜잭션)

### DIFF
--- a/firebase/functions/src/Study/triggers.ts
+++ b/firebase/functions/src/Study/triggers.ts
@@ -1,0 +1,41 @@
+import {onDocumentCreated} from "firebase-functions/v2/firestore";
+import {generateStudyContent} from "./gen_ai_service";
+import {logger} from "firebase-functions";
+import {getOrCreateStudy, saveStudy} from "./firestore_service";
+
+export const studyTrigger = onDocumentCreated(
+  {
+    document: "users/{uid}/roadmap/{roadmapId}",
+    timeoutSeconds: 300,
+  },
+  async (event) => {
+    const data = event.data;
+
+    logger.info("[TRIGGER TEST] 'studyTrigger' 함수가 실행되었습니다!");
+
+
+    if (!data) {
+      logger.log(`컬랙션 ${event.params.roadmapId} 이 삭제되거나 없습니다.`);
+      return;
+    }
+
+    const roadmapData = data.data();
+    const questionId = roadmapData.from;
+
+    const uid = event.params.uid;
+    const roadmapId = event.params.roadmapId;
+
+    logger.log(`New roadmap created for user ${uid}. Generating studies for roadmap ${roadmapId}...`);
+
+    const studyData = await generateStudyContent(uid, questionId, roadmapId);
+
+    // Firestore 서비스 호출
+    const {studyRef, existingStudy} = await getOrCreateStudy(uid);
+
+    // Firestore에 저장
+    await saveStudy(studyRef, studyData, existingStudy === null);
+
+    logger.log("AI Study 생성 및 저장 성공", studyData);
+    return {message: "AI 응답 성공", study: studyData};
+  }
+);

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -19,3 +19,7 @@ export * from "./roadmap/roadmap";
 export * from "./quiz/quiz";
 export * from "./auth/naver";
 export * from "./Study/study";
+
+// Triggers
+export {studyTrigger} from "./Study/triggers";
+export {quizTrigger} from "./quiz/triggers";

--- a/firebase/functions/src/quiz/triggers.ts
+++ b/firebase/functions/src/quiz/triggers.ts
@@ -1,0 +1,40 @@
+import {onDocumentCreated} from "firebase-functions/v2/firestore";
+import {getQuiz} from "./gen_ai_service";
+import {getConceptDetail, saveQuiz} from "./firestore_service";
+import {logger} from "firebase-functions";
+
+export const quizTrigger = onDocumentCreated(
+  {
+    document: "users/{uid}/studies/{studyId}",
+    timeoutSeconds: 300,
+  },
+  async (event) => {
+    const data = event.data;
+
+    logger.info("[TRIGGER TEST] 'quizTrigger' 함수가 실행되었습니다!");
+
+
+    if (!data) {
+      logger.log(`컬랙션 ${event.params.studyId} 이 삭제되거나 없습니다.`);
+      return;
+    }
+
+    const uid = event.params.uid;
+    const studyId = event.params.studyId;
+
+    // 3. 개념 상세 데이터 조회 (Firestore Service)
+    const conceptDetail = await getConceptDetail(uid, studyId);
+
+    // 4. AI 응답 요청 (Gemini Service)
+    const aiResponse = await getQuiz(conceptDetail, studyId);
+
+    // 5. 퀴즈 내용 저장 (Firestore Service)
+    await saveQuiz(uid, aiResponse);
+
+    // 6. 응답 반환
+    return {
+      ...aiResponse,
+      createdAt: new Date().toISOString(),
+    };
+  }
+);

--- a/firebase/functions/src/roadmap/roadmap.ts
+++ b/firebase/functions/src/roadmap/roadmap.ts
@@ -34,7 +34,12 @@ export const generateRoadmap = onCall(async (request) => {
 
     const roadmap = cleanAndParseAiResponse<Roadmap>(rawAiOutput);
 
-    const roadmapRefId = await saveRoadmap(uid, roadmap);
+    const finalRoadmap: Roadmap = {
+      ...roadmap,
+      from: questionId,
+    };
+
+    const roadmapRefId = await saveRoadmap(uid, finalRoadmap);
 
     console.log(`roadmapRefId: ${roadmapRefId}`); // 예: "4z8QJXyBcM7n2Jgf1ZpA"
 

--- a/firebase/functions/src/type/roadmap_types.ts
+++ b/firebase/functions/src/type/roadmap_types.ts
@@ -1,5 +1,6 @@
 export interface Roadmap {
   title: string;
+  from: string;
   description: string;
   stages: Stage[];
 }


### PR DESCRIPTION
Firestore Trigger 추가 (https://firebase.google.com/docs/functions/firestore-events?hl=ko)

작업 대상
- 개념 상세 파일 생성
- 퀴즈 데이터 생성

트리거 수행 기간은 5분 설정(AI 응답 대기시간 고려)

기타
- roadmap 필드 안에 'from' 값 추가(질문 ID)