### PR TITLE
[fix/route/all] 전체적인 라우팅 수정

### DIFF
--- a/app/src/main/java/com/aspa/aspa/MainActivity.kt
+++ b/app/src/main/java/com/aspa/aspa/MainActivity.kt
@@ -1,29 +1,11 @@
 package com.aspa.aspa
 
-import android.app.Activity
-import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.runtime.Composable
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import com.aspa.aspa.features.login.LoginScreen
-import com.aspa.aspa.features.login.NicknameScreen
-import com.aspa.aspa.features.main.MainScreen
+import com.aspa.aspa.features.navigation.AppNavigation
 import com.aspa.aspa.ui.theme.AspaTheme
-import com.google.firebase.Firebase
-import com.google.firebase.auth.OAuthProvider
-import com.google.firebase.auth.auth
-import com.google.firebase.firestore.FieldValue
-import com.google.firebase.firestore.firestore
-import com.kakao.sdk.auth.model.OAuthToken
-import com.kakao.sdk.common.model.ClientError
-import com.kakao.sdk.common.model.ClientErrorCause
-import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -37,34 +19,6 @@ class MainActivity : ComponentActivity() {
             AspaTheme {
                 AppNavigation()
             }
-        }
-    }
-}
-
-
-@Composable
-fun AppNavigation() {
-    val navController = rememberNavController()
-    NavHost(navController = navController, startDestination = "login") {
-        composable("login") {
-            LoginScreen(navController)
-        }
-        composable("nickname") {
-            NicknameScreen(
-                onNavigateToPrevious = {
-                    navController.popBackStack()
-                },
-                onNavigateToNext = {
-                    // "main"으로 이동하도록 수정
-                    navController.navigate("main") {
-                        popUpTo("login") { inclusive = true }
-                    }
-                }
-            )
-        }
-        composable("main") {
-            // navController를 전달하지 않음
-            MainScreen()
         }
     }
 }

--- a/app/src/main/java/com/aspa/aspa/features/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/aspa/aspa/features/home/navigation/HomeNavigation.kt
@@ -17,8 +17,8 @@ import com.aspa.aspa.features.home.HomeViewModel
 import com.aspa.aspa.features.roadmap.navigation.RoadmapDestinations
 
 object HomeDestinations {
+    const val HOME_GRAPH_ROUTE = "home_graph"
     const val HOME = "home"
-    const val HOME_GRAPH_ROUTE = "homeGraph"
 }
 
 fun NavGraphBuilder.homeGraph(

--- a/app/src/main/java/com/aspa/aspa/features/login/LoginScreen.kt
+++ b/app/src/main/java/com/aspa/aspa/features/login/LoginScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,16 +34,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
+import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.aspa.aspa.features.login.components.SocialButton
-import com.aspa.aspa.features.login.navigation.LoginDestinations
-import com.google.firebase.Firebase
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
+import com.aspa.aspa.features.main.navigation.MainDestinations
+import com.aspa.aspa.util.DoubleBackExitHandler
 import com.navercorp.nid.NaverIdLoginSDK
-import androidx.compose.runtime.getValue
-import androidx.navigation.NavController
 
 @Composable
 fun LoginScreen(
@@ -50,24 +47,27 @@ fun LoginScreen(
     loginViewModel: LoginViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
+    val loginState by loginViewModel.loginState.collectAsState()
+
     val naverLauncher = rememberNaverLoginLauncher(
         onAccessToken = { token ->
             loginViewModel.signInWithNaver(token)
         },
         onSuccess = {
-            navController.navigate("main")
+            navController.navigate(MainDestinations.MAIN)
         },
     )
-    val loginState by loginViewModel.loginState.collectAsState()
 
     LaunchedEffect(loginState) {
         if (loginState is LoginState.Success) {
-            navController.navigate("main") /*{
-                popUpTo("login") { inclusive = true } // 뒤로가기 시 로그인화면 안보이게
+            navController.navigate(MainDestinations.MAIN) {
+                popUpTo(0) { inclusive = true }
                 launchSingleTop = true
-            }*/
+            }
         }
     }
+
+    DoubleBackExitHandler()
 
     Box(
         modifier = Modifier
@@ -128,7 +128,7 @@ fun LoginScreen(
 
                 Button(
                     onClick = {
-                        navController.navigate(LoginDestinations.NICKNAME)
+//                        navController.navigate(LoginDestinations.NICKNAME)
                     },
                     modifier = Modifier
                         .fillMaxWidth(),

--- a/app/src/main/java/com/aspa/aspa/features/login/navigation/LoginNavigation.kt
+++ b/app/src/main/java/com/aspa/aspa/features/login/navigation/LoginNavigation.kt
@@ -2,69 +2,26 @@ package com.aspa.aspa.features.login.navigation
 
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.aspa.aspa.features.login.LoginScreen
-import com.aspa.aspa.features.login.NicknameScreen
-import com.aspa.aspa.features.main.MainScreen
 
 object LoginDestinations {
-    const val GRAPH = "login_graph"
+    const val LOGIN_GRAPH_ROUTE = "login_graph"
     const val LOGIN = "login"
-    const val NICKNAME = "nickname"
 }
 
 fun NavGraphBuilder.loginGraph(
     navController: NavController,
-    onLoginSuccess: () -> Unit
 ) {
     navigation(
         startDestination = LoginDestinations.LOGIN,
-        route = LoginDestinations.GRAPH
+        route = LoginDestinations.LOGIN_GRAPH_ROUTE
     ) {
         composable(LoginDestinations.LOGIN) {
             LoginScreen(
-                navController as NavHostController,
-//                onGoogleSignInClick = {
-//                    googleSignInLauncher.launch(googleSignInClient.signInIntent)
-//                },
-//                onKakaoSignInClick = { /* TODO: Kakao 로그인  */ },
-//                onNaverSignInClick = { /* TODO: Naver 로그인  */ },
-//                onLoginClick = {
-//                    Auth.uid = "test-user-for-web"
-//                    navController.navigate("nickname")
-//                }
+                navController,
             )
-        }
-
-        composable(LoginDestinations.NICKNAME) {
-            NicknameScreen(
-                onNavigateToPrevious = {
-                    navController.popBackStack()
-                },
-                onNavigateToNext = { _finalNickname ->  // todo: 닉네임 누락 // viewModel에서 처리
-                    // 닉네임 확정 → 상위(AppNavHost)로 성공 신호 전달
-                    onLoginSuccess()
-                }
-            )
-        }
-
-//        composable("nickname") {
-//            NicknameScreen(
-//                onNavigateToPrevious = {
-//                    navController.popBackStack()
-//                },
-//                onNavigateToNext = { finalNickname ->
-//                    navController.navigate("main/$finalNickname") {
-//                        popUpTo("login") { inclusive = true }
-//                    }
-//                }
-//            )
-//        }
-
-        composable("main") { backStackEntry ->
-            MainScreen()
         }
     }
 }

--- a/app/src/main/java/com/aspa/aspa/features/main/MainScreen.kt
+++ b/app/src/main/java/com/aspa/aspa/features/main/MainScreen.kt
@@ -1,44 +1,38 @@
 package com.aspa.aspa.features.main
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.aspa.aspa.features.home.HomeViewModel
 import com.aspa.aspa.features.home.components.HomeDrawerContent
 import com.aspa.aspa.features.home.navigation.HomeDestinations
-import com.aspa.aspa.features.home.navigation.homeGraph
 import com.aspa.aspa.features.main.components.BottomNavigationBar
 import com.aspa.aspa.features.main.components.DefaultTopBar
 import com.aspa.aspa.features.main.components.HomeTopBar
-import com.aspa.aspa.features.main.navigation.BottomTab
-import com.aspa.aspa.features.mypage.navigation.mypageGraph
+import com.aspa.aspa.features.main.navigation.MainNavigation
+import com.aspa.aspa.features.mypage.navigation.MypageDestination
 import com.aspa.aspa.features.quiz.navigation.QuizDestinations
-import com.aspa.aspa.features.quiz.navigation.quizGraph
 import com.aspa.aspa.features.roadmap.components.RoadmapTopBar
 import com.aspa.aspa.features.roadmap.navigation.RoadmapDestinations
-import com.aspa.aspa.features.roadmap.navigation.roadmapGraph
+import com.aspa.aspa.util.DoubleBackExitHandler
 import kotlinx.coroutines.launch
 
 @SuppressLint("RestrictedApi", "StateFlowValueCalledInComposition")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
+    rootNavController: NavHostController,
     homeViewModel: HomeViewModel = hiltViewModel()
 ) {
 
@@ -48,6 +42,8 @@ fun MainScreen(
     val scope = rememberCoroutineScope()
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val uiState by homeViewModel.uiState.collectAsState()
+
+    DoubleBackExitHandler()
 
     ModalNavigationDrawer(
         drawerState = drawerState,
@@ -88,10 +84,10 @@ fun MainScreen(
             },
             bottomBar = {
                 val bottomNavScreenRoutes = listOf(
-                    BottomTab.Home.route,
-                    BottomTab.Roadmap.route,
-                    BottomTab.Quiz.route,
-                    BottomTab.MyPage.route
+                    HomeDestinations.HOME,
+                    RoadmapDestinations.ROADMAP_LIST,
+                    QuizDestinations.QUIZ,
+                    MypageDestination.MYPAGE
                 )
 
                 val shouldShowBottomBar = currentRoute in bottomNavScreenRoutes
@@ -101,7 +97,7 @@ fun MainScreen(
                         currentRoute = currentRoute,
                         onTabSelected = { graphRoute ->
                             innerNavController.navigate(graphRoute) {
-                                popUpTo(innerNavController.graph.findStartDestination().id) {
+                                popUpTo(0) {
                                     saveState = true
                                 }
                                 launchSingleTop = true
@@ -112,16 +108,12 @@ fun MainScreen(
                 }
             }
         ) { innerPadding ->
-            NavHost(
-                navController = innerNavController,
-                startDestination = HomeDestinations.HOME_GRAPH_ROUTE,
-                modifier = Modifier.padding(innerPadding)
-            ) {
-                homeGraph(navController = innerNavController, homeViewModel = homeViewModel)
-                roadmapGraph(navController = innerNavController)
-                quizGraph(navController = innerNavController)
-                mypageGraph(navController = innerNavController)
-            }
+            MainNavigation(
+                rootNavController = rootNavController,
+                innerNavController = innerNavController,
+                innerPadding = innerPadding,
+                homeViewModel = homeViewModel,
+            )
         }
     }
 }

--- a/app/src/main/java/com/aspa/aspa/features/main/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/aspa/aspa/features/main/components/BottomNavigationBar.kt
@@ -10,6 +10,9 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import com.aspa.aspa.features.home.navigation.HomeDestinations
+import com.aspa.aspa.features.mypage.navigation.MypageDestination
+import com.aspa.aspa.features.quiz.navigation.QuizDestinations
 import com.aspa.aspa.features.roadmap.navigation.RoadmapDestinations
 
 @Composable
@@ -19,26 +22,26 @@ fun BottomNavigationBar(
 ) {
     NavigationBar {
         NavigationBarItem(
-            selected = currentRoute == "home",
-            onClick = { onTabSelected("home") },
+            selected = currentRoute == HomeDestinations.HOME,
+            onClick = { onTabSelected(HomeDestinations.HOME_GRAPH_ROUTE) },
             icon = { Icon(Icons.Default.Home, contentDescription = "홈") },
             label = { Text("홈") }
         )
         NavigationBarItem(
-            selected = currentRoute == "quiz",
-            onClick = { onTabSelected("quiz") },
+            selected = currentRoute == QuizDestinations.QUIZ,
+            onClick = { onTabSelected(QuizDestinations.QUIZ_GRAPH_ROUTE) },
             icon = { Icon(Icons.Default.Checklist, contentDescription = "퀴즈") },
             label = { Text("퀴즈") }
         )
         NavigationBarItem(
-            selected = currentRoute?.startsWith("roadmap") == true,
-            onClick = { onTabSelected(RoadmapDestinations.roadmapList()) },
+            selected = currentRoute == RoadmapDestinations.ROADMAP_LIST,
+            onClick = { onTabSelected(RoadmapDestinations.ROADMAP_GRAPH_ROUTE) },
             icon = { Icon(Icons.Default.Explore, contentDescription = "로드맵") },
             label = { Text("로드맵") }
         )
         NavigationBarItem(
-            selected = currentRoute == "mypage",
-            onClick = { onTabSelected("mypage") },
+            selected = currentRoute == MypageDestination.MYPAGE,
+            onClick = { onTabSelected(MypageDestination.MYPAGE_GRAPH_ROUTE) },
             icon = { Icon(Icons.Default.Person, contentDescription = "마이페이지") },
             label = { Text("마이페이지") }
         )

--- a/app/src/main/java/com/aspa/aspa/features/main/navigation/MainNavigation.kt
+++ b/app/src/main/java/com/aspa/aspa/features/main/navigation/MainNavigation.kt
@@ -1,19 +1,37 @@
 package com.aspa.aspa.features.main.navigation
 
-object MainDestinations { const val GRAPH = "main_graph" }
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import com.aspa.aspa.features.home.HomeViewModel
+import com.aspa.aspa.features.home.navigation.HomeDestinations
+import com.aspa.aspa.features.home.navigation.homeGraph
+import com.aspa.aspa.features.mypage.navigation.mypageGraph
+import com.aspa.aspa.features.quiz.navigation.quizGraph
+import com.aspa.aspa.features.roadmap.navigation.roadmapGraph
 
-enum class BottomTab(val route: String) {
-    Home("home"), Roadmap("roadmap?questionId={questionId}"), Quiz("quiz"), MyPage("mypage")
+object MainDestinations { const val MAIN = "main" }
+
+
+@Composable
+fun MainNavigation(
+    rootNavController: NavHostController,
+    innerNavController: NavHostController,
+    innerPadding: PaddingValues,
+    homeViewModel: HomeViewModel
+) {
+
+    NavHost(
+        navController = innerNavController,
+        startDestination = HomeDestinations.HOME_GRAPH_ROUTE,
+        modifier = Modifier.padding(innerPadding)
+    ) {
+        homeGraph(navController = innerNavController, homeViewModel = homeViewModel)
+        roadmapGraph(navController = innerNavController)
+        quizGraph(navController = innerNavController)
+        mypageGraph(rootNavController = rootNavController,innerNavController = innerNavController)
+    }
 }
-
-//fun NavGraphBuilder.mainGraph(navController: NavController) {
-//    navigation(
-//        startDestination = BottomTab.Home.route,
-//        route = MainDestinations.GRAPH
-//    ) {
-//        homeGraph(navController = navController, homeViewModel = HomeViewModel())
-//        roadmapGraph(navController = navController)
-//        quizGraph(navController = navController)
-//        mypageGraph(navController = navController)
-//    }
-//}

--- a/app/src/main/java/com/aspa/aspa/features/mypage/MypageScreen.kt
+++ b/app/src/main/java/com/aspa/aspa/features/mypage/MypageScreen.kt
@@ -3,6 +3,7 @@ package com.aspa.aspa.features.mypage
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,9 +16,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Logout
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material.icons.outlined.Logout
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -33,15 +34,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.aspa.aspa.features.login.navigation.LoginDestinations
 import com.aspa.aspa.ui.theme.Gray10
 
 @OptIn(ExperimentalMaterial3Api::class)
-@Preview(showBackground = true)
 @Composable
-fun MyPageScreen() {
+fun MyPageScreen(rootNavController: NavHostController,innerNavController: NavHostController) {
     Scaffold(
         topBar = {
             CenterAlignedTopAppBar(
@@ -134,15 +135,21 @@ fun MyPageScreen() {
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 20.dp, vertical = 15.dp)
-                        .background(Color.Red, shape = RoundedCornerShape(5.dp)),
-                    contentAlignment = Alignment.Center
+                        .background(Color.Red, shape = RoundedCornerShape(5.dp))
+                        .clickable{
+                            rootNavController.navigate(LoginDestinations.LOGIN_GRAPH_ROUTE) {
+                                popUpTo(0)
+                            }
+                        },
+                    contentAlignment = Alignment.Center,
+
                 ){
                     Row(
                         modifier = Modifier
                             .padding(8.dp)
                     ) {
                         Icon(
-                            imageVector = Icons.Outlined.Logout,
+                            imageVector = Icons.AutoMirrored.Outlined.Logout,
                             contentDescription = "로그아웃",
                             modifier = Modifier
                                 .size(20.dp),

--- a/app/src/main/java/com/aspa/aspa/features/mypage/navigation/MypageNavigation.kt
+++ b/app/src/main/java/com/aspa/aspa/features/mypage/navigation/MypageNavigation.kt
@@ -1,13 +1,22 @@
 package com.aspa.aspa.features.mypage.navigation
 
-import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.navigation
 import com.aspa.aspa.features.mypage.MyPageScreen
 
-
-fun NavGraphBuilder.mypageGraph(navController: NavController) {
-    composable("mypage") {
-        MyPageScreen()
+object MypageDestination {
+    const val MYPAGE_GRAPH_ROUTE = "mypage_graph"
+    const val MYPAGE = "mypage"
+}
+fun NavGraphBuilder.mypageGraph(rootNavController: NavHostController,innerNavController: NavHostController) {
+    navigation(
+        startDestination = MypageDestination.MYPAGE,
+        route = MypageDestination.MYPAGE_GRAPH_ROUTE
+    ) {
+        composable(MypageDestination.MYPAGE) {
+            MyPageScreen(rootNavController, innerNavController)
+        }
     }
 }

--- a/app/src/main/java/com/aspa/aspa/features/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/aspa/aspa/features/navigation/AppNavHost.kt
@@ -10,33 +10,16 @@ import com.aspa.aspa.features.main.MainScreen
 import com.aspa.aspa.features.main.navigation.MainDestinations
 
 @Composable
-fun AppNavHost(isSignedIn: Boolean) {
+fun AppNavigation() {
     val navController = rememberNavController()
 
-//    val loginViewModel: LoginViewModel = viewModel()  // todo: 연동 필요
-//    val googleSignInClient = rememberGoogleSignInClient()
-//    val googleSignInLauncher = googleSignInHandler(
-//        viewModel = loginViewModel,
-//        navController = navController
-//    )
+    NavHost(navController = navController, startDestination = LoginDestinations.LOGIN_GRAPH_ROUTE) {
 
+        loginGraph(navController)
 
-    NavHost(
-        navController = navController,
-        startDestination = if (isSignedIn) MainDestinations.GRAPH else LoginDestinations.GRAPH
-    ) {
-        loginGraph(
-            navController,
-            onLoginSuccess = {
-                navController.navigate(MainDestinations.GRAPH) {
-                    popUpTo(LoginDestinations.GRAPH) { inclusive = true }
-                    launchSingleTop = true
-                }
-            }
-        )
-//        mainGraph(navController) // 하단 탭이 있는 메인 그래프
-        composable(MainDestinations.GRAPH) {
-            MainScreen()
+        composable(MainDestinations.MAIN) {
+            // navController를 전달하지 않음
+            MainScreen(navController)
         }
     }
 }

--- a/app/src/main/java/com/aspa/aspa/features/quiz/navigation/QuizNavigation.kt
+++ b/app/src/main/java/com/aspa/aspa/features/quiz/navigation/QuizNavigation.kt
@@ -11,14 +11,8 @@ import com.aspa.aspa.features.quiz.QuizScreen
 import com.aspa.aspa.features.quiz.QuizViewModel
 import com.aspa.aspa.features.quiz.SolveQuizScreen
 
-/** 퀴즈 라우트 상수 */
-//sealed class QuizScreenRoute(val route: String) {
-//    object Quiz : QuizScreenRoute("quiz")
-//    object SolveQuiz : QuizScreenRoute("quiz_solve")
-//    object QuizResult : QuizScreenRoute("quiz_result")
-//}
-
 object QuizDestinations {
+    const val QUIZ_GRAPH_ROUTE = "quiz_graph"
     const val QUIZ = "quiz"
     const val SOLVE_QUIZ = "quiz_solve"
     const val QUIZ_RESULT = "quiz_result"
@@ -29,12 +23,12 @@ fun NavGraphBuilder.quizGraph(navController: NavController) {
 
     navigation(
         startDestination = QuizDestinations.QUIZ,
-        route = "quizGraph"
+        route = QuizDestinations.QUIZ_GRAPH_ROUTE
     ) {
         composable(QuizDestinations.QUIZ) { backStackEntry ->
             // navController에서 부모 그래프('quizGraph')의 BackStackEntry를 가져옵니다.
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry("quizGraph")
+                navController.getBackStackEntry(QuizDestinations.QUIZ_GRAPH_ROUTE)
             }
             // 부모 Entry를 기준으로 ViewModel을 생성하여 공유 인스턴스를 사용합니다.
             val viewModel: QuizViewModel = hiltViewModel(parentEntry)
@@ -43,7 +37,7 @@ fun NavGraphBuilder.quizGraph(navController: NavController) {
 
         composable(QuizDestinations.SOLVE_QUIZ) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry("quizGraph")
+                navController.getBackStackEntry(QuizDestinations.QUIZ_GRAPH_ROUTE)
             }
             val viewModel: QuizViewModel = hiltViewModel(parentEntry)
             SolveQuizScreen(navController, viewModel)
@@ -51,7 +45,7 @@ fun NavGraphBuilder.quizGraph(navController: NavController) {
 
         composable(QuizDestinations.QUIZ_RESULT) { backStackEntry ->
             val parentEntry = remember(backStackEntry) {
-                navController.getBackStackEntry("quizGraph")
+                navController.getBackStackEntry(QuizDestinations.QUIZ_GRAPH_ROUTE)
             }
             val viewModel: QuizViewModel = hiltViewModel(parentEntry)
             QuizResultScreen(navController, viewModel)

--- a/app/src/main/java/com/aspa/aspa/features/roadmap/navigation/RoadmapNavigation.kt
+++ b/app/src/main/java/com/aspa/aspa/features/roadmap/navigation/RoadmapNavigation.kt
@@ -5,11 +5,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import androidx.navigation.navigation
 import com.aspa.aspa.features.roadmap.RoadmapDetailScreen
 import com.aspa.aspa.features.roadmap.RoadmapListScreen
 import com.aspa.aspa.features.roadmap.components.RoadmapDialog
 
 object RoadmapDestinations {
+    const val ROADMAP_GRAPH_ROUTE = "roadmap_graph"
     const val ROADMAP_LIST = "roadmap?questionId={questionId}"
     const val ROADMAP_DETAIL = "roadmap/{roadmapId}"
     const val ROADMAP_DIALOG = "roadmap/{roadmapId}/{sectionId}"
@@ -25,45 +27,50 @@ object RoadmapDestinations {
 }
 
 fun NavGraphBuilder.roadmapGraph(navController: NavController) {
-    composable(
-        route = RoadmapDestinations.ROADMAP_LIST,
-        arguments = listOf(navArgument("questionId") {
-            type = NavType.StringType
-            defaultValue = ""
-        })
-    ) {backStackEntry ->
-        val questionId = backStackEntry.arguments?.getString("questionId") ?: ""
-        RoadmapListScreen(
-            navController = navController,
-            questionId = questionId
-        )
-    }
-
-    composable(
-        route = RoadmapDestinations.ROADMAP_DETAIL,
-        arguments =
-            listOf(
-                navArgument("roadmapId") { type = NavType.StringType },
+    navigation(
+        startDestination = RoadmapDestinations.ROADMAP_LIST,
+        route = RoadmapDestinations.ROADMAP_GRAPH_ROUTE
+    ) {
+        composable(
+            route = RoadmapDestinations.ROADMAP_LIST,
+            arguments = listOf(navArgument("questionId") {
+                type = NavType.StringType
+                defaultValue = ""
+            })
+        ) {backStackEntry ->
+            val questionId = backStackEntry.arguments?.getString("questionId") ?: ""
+            RoadmapListScreen(
+                navController = navController,
+                questionId = questionId
             )
-    ) { backStackEntry ->
-        val roadmapId = backStackEntry.arguments?.getString("roadmapId")
+        }
 
-        RoadmapDetailScreen(roadmapId!!, navController)
-    }
+        composable(
+            route = RoadmapDestinations.ROADMAP_DETAIL,
+            arguments =
+                listOf(
+                    navArgument("roadmapId") { type = NavType.StringType },
+                )
+        ) { backStackEntry ->
+            val roadmapId = backStackEntry.arguments?.getString("roadmapId")
 
-    composable(
-        route = RoadmapDestinations.ROADMAP_DIALOG,
-        arguments = listOf(
-            navArgument("roadmapId") { type = NavType.StringType },
-            navArgument("sectionId") { type = NavType.IntType },
-        )
-    ) { backStackEntry ->
-        val roadmapId = backStackEntry.arguments?.getString("roadmapId")
-        val sectionId = backStackEntry.arguments?.getInt("sectionId")
-        RoadmapDialog(
-            roadmapId = roadmapId!!,
-            sectionId = sectionId!!,
-            navController = navController
-        )
+            RoadmapDetailScreen(roadmapId!!, navController)
+        }
+
+        composable(
+            route = RoadmapDestinations.ROADMAP_DIALOG,
+            arguments = listOf(
+                navArgument("roadmapId") { type = NavType.StringType },
+                navArgument("sectionId") { type = NavType.IntType },
+            )
+        ) { backStackEntry ->
+            val roadmapId = backStackEntry.arguments?.getString("roadmapId")
+            val sectionId = backStackEntry.arguments?.getInt("sectionId")
+            RoadmapDialog(
+                roadmapId = roadmapId!!,
+                sectionId = sectionId!!,
+                navController = navController
+            )
+        }
     }
 }

--- a/app/src/main/java/com/aspa/aspa/util/DoubleBackExitHandler.kt
+++ b/app/src/main/java/com/aspa/aspa/util/DoubleBackExitHandler.kt
@@ -1,0 +1,27 @@
+package com.aspa.aspa.util
+
+import android.app.Activity
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun DoubleBackExitHandler() {
+    val context = LocalContext.current
+    var backPressedTime by remember { mutableLongStateOf(0L) }
+
+    BackHandler {
+        val currentTime = System.currentTimeMillis()
+        if (currentTime - backPressedTime > 2000) {
+            Toast.makeText(context, "한 번 더 누르면 앱이 종료됩니다.", Toast.LENGTH_SHORT).show()
+            backPressedTime = currentTime
+        } else {
+            (context as? Activity)?.finish()
+        }
+    }
+}


### PR DESCRIPTION
불안정했던 라우팅 코드 전체적으로 점검하고 수정하였습니다.

- 기존 라우팅 코드의 하드코딩값 -> Destinations값으로 수정
- 화면 별 Destinations의 형식 통일
- 로드맵 그래프 추가
- 마이페이지 그래프 추가
- NavHost 정리
  - rootNavHost -> AppNavHost.kt
  - innerNavHost -> MainNavigation.kt
- bottomBar의 라우팅 경로 수정
  - 라우팅 시 화면 -> 그래프로 수정
  - bottomTab 제거
- 2번 뒤로가기 시 종료 핸들러 적용
- 로그아웃 버튼 클릭 시 로그인 화면으로 라우팅 적용