### PR TITLE
[fix/route/generate roadmap] 로드맵 생성 직후 홈으로 라우팅이 불가능한 문제 해결

### DIFF
--- a/app/src/main/java/com/aspa/aspa/features/roadmap/RoadmapListScreen.kt
+++ b/app/src/main/java/com/aspa/aspa/features/roadmap/RoadmapListScreen.kt
@@ -43,7 +43,7 @@ fun RoadmapListScreen(
             viewModel.generateRoadmap(questionId) { roadmapId ->
                 // 먼저 questionId 없는 목록으로 교체
                 navController.navigate(RoadmapDestinations.roadmapList()) {
-                    popUpTo(RoadmapDestinations.ROADMAP_LIST) { inclusive = true }
+                    popUpTo(0)
                 }
                 // 그 다음에 상세 화면으로 이동
                 navController.navigate(


### PR DESCRIPTION
로드맵 생성 이후 로드맵 쪽에서 라우팅 시 백스택이 중간에 끊겨서 생긴 문제였습니다.

로드맵 라우팅 시 백스택을 전부 제거하는 방향으로 트러블슈팅하였습니다.