### PR TITLE
[fix/firebase/trigger] 퀴즈 트리거 실패 개선

### DIFF
--- a/firebase/functions/src/quiz/triggers.ts
+++ b/firebase/functions/src/quiz/triggers.ts
@@ -24,7 +24,7 @@ export const quizTrigger = onDocumentCreated(
     const sectionId = studyData.sectionId;
     const roadmapId = studyData.roadmapId;
 
-    if (!sectionId || !roadmapId) {
+    if (sectionId === undefined || !roadmapId) {
       logger.error(`Study 문서(${studyId})에 'sectionId' 또는 'roadmapId' 필드가 없습니다.`);
       return;
     }


### PR DESCRIPTION
약 타입 언어 특성 상 sectionId 0 일 때 숫자로 인식하지 않음.
