### PR TITLE
[fix/design/quiz] 퀴즈 화면 디자인 개선

### DIFF
--- a/app/src/main/java/com/aspa/aspa/features/quiz/SolveQuizScreen.kt
+++ b/app/src/main/java/com/aspa/aspa/features/quiz/SolveQuizScreen.kt
@@ -163,7 +163,6 @@ fun SolveQuizScreen(
                                         if (selectedOption == option) {
                                             Card(
                                                 modifier = Modifier
-                                                    .padding(start = 4.dp)
                                                     .fillMaxWidth()
                                                     .fillMaxHeight(),
                                                 colors = CardDefaults.cardColors(
@@ -173,12 +172,15 @@ fun SolveQuizScreen(
                                             ) {
                                                 Box(contentAlignment = Alignment.CenterStart,
                                                     modifier = Modifier.fillMaxSize()
+                                                        .padding(start = 6.dp)
                                                 ) {
                                                     optionText()
                                                 }
 
                                             }
                                         } else {
+                                            Spacer(modifier = Modifier.width(6.dp))
+
                                             optionText()
                                         }
 

--- a/app/src/main/java/com/aspa/aspa/features/quiz/SolveQuizScreen.kt
+++ b/app/src/main/java/com/aspa/aspa/features/quiz/SolveQuizScreen.kt
@@ -36,13 +36,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.compose.rememberNavController
 import com.aspa.aspa.features.quiz.navigation.QuizDestinations
 
 
@@ -156,7 +153,7 @@ fun SolveQuizScreen(
                                             Text(
                                                 text = option,
                                                 modifier = Modifier
-                                                    .padding(horizontal = 6.dp)
+                                                    .padding(horizontal = 10.dp)
                                             )
                                         }
 

--- a/app/src/main/java/com/aspa/aspa/features/quiz/component/QuestionCard.kt
+++ b/app/src/main/java/com/aspa/aspa/features/quiz/component/QuestionCard.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -56,12 +57,12 @@ fun QuestionCard(
                 Column(modifier = Modifier.padding(16.dp)) {
 
                     // 문제 제목
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(verticalAlignment = Alignment.Top) {
                         Icon(
                             imageVector = icon,
                             contentDescription = null,
                             tint = tint,
-                            modifier = Modifier.size(20.dp)
+                            modifier = Modifier.size(20.dp).padding(top = 4.dp)
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(

--- a/app/src/main/java/com/aspa/aspa/features/quiz/component/QuizListCard.kt
+++ b/app/src/main/java/com/aspa/aspa/features/quiz/component/QuizListCard.kt
@@ -80,9 +80,13 @@ fun QuizListCard(
                     Text(
                         text = title,
                         style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurface
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
+
+                Spacer(modifier = Modifier.width(8.dp))
 
                 if (completedSection != 0 && completedSection != allSection) {
                     Card(


### PR DESCRIPTION
- 퀴즈 카드의 타이틀과 진행도 간에 간격 주고 ellipsis 처리
- 퀴즈 풀기 중 선택 시 글자와 배경 사이 간격 개선
- 퀴즈 결과의 문제 별 정답/오답 아이콘을 가운데 정렬이 아닌 top 정렬로 변경