### PR TITLE
[fix/a01] 홈 화면 질문 시 응답 결과 스크롤링 안됨 증상 해결

### DIFF
--- a/app/src/main/java/com/aspa/aspa/features/home/components/ChatComponents.kt
+++ b/app/src/main/java/com/aspa/aspa/features/home/components/ChatComponents.kt
@@ -29,8 +29,10 @@ fun ChatContent(
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
-    LaunchedEffect(messages.size) {
-        if (messages.isNotEmpty()) listState.animateScrollToItem(messages.lastIndex)
+    LaunchedEffect(messages.lastOrNull()) {
+        if (messages.isNotEmpty()) {
+            listState.animateScrollToItem(messages.lastIndex)
+        }
     }
 
     LazyColumn(


### PR DESCRIPTION
문제 : 스크롤링이 전부 내려가지 않았음
원인
- 낙관적ui 적용된 컴포넌트가 우선 표출이 되면서 스크롤링이 이때 동작함.
- 추후 통신 응답으로 ui를 업데이트하면서 컨텐츠의 높이가 더 길어짐.

기존 로직에서는 메시지 기록의 개수 변화를 바탕으로 스크롤링 처리함.
따라서, 업데이트된 컴포넌트는 반영되지 않았음.

개선 : 마지막 아이템 객체의 변화를 바탕으로 스크롤링