### PR TITLE
[fix/migration-roadmap] roadmap-stage 의 id numbering 수정 (0부터 시작)

### DIFF
--- a/firebase/functions/src/ai/roadmap_prompt.ts
+++ b/firebase/functions/src/ai/roadmap_prompt.ts
@@ -49,4 +49,5 @@ export const ROADMAP_SYSTEM_PROMPT = `
  
  
 응답 결과 중 각 stage 객체의 status는 항상 false로 응답해줘.
+응답 결과 중 stage의 id는 0부터 시작하는 연속된 숫자로 응답해줘.
 `;


### PR DESCRIPTION
json 스키마 지정으로 인해 
프롬프트 중 roadmap-stage-id 의 경우 0부터 시작되는 규칙 누락

해당 규칙을 프롬프트에 다시 추가하였습니다.

배포 완료